### PR TITLE
fix for over-broad container_runtime_exec_t

### DIFF
--- a/policy/centos7/k3s.fc
+++ b/policy/centos7/k3s.fc
@@ -14,6 +14,8 @@
 /var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?         gen_context(system_u:object_r:container_share_t,s0)
 /var/lib/rancher/k3s/data(/.*)?                                     gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /var/lib/rancher/k3s/storage(/.*)?                                  gen_context(system_u:object_r:container_file_t,s0)
+/var/lib/rancher/k3s/data/.lock                                      gen_context(system_u:object_r:container_lock_t,s0)
+/var/lib/rancher/k3s/data/[^/]*/etc(/.*)?                            gen_context(system_u:object_r:container_config_t,s0)
 /var/log/containers(/.*)?                                           gen_context(system_u:object_r:container_log_t,s0)
 /var/log/pods(/.*)?                                                 gen_context(system_u:object_r:container_log_t,s0)
 /var/run/flannel(/.*)?                                              gen_context(system_u:object_r:container_var_run_t,s0)

--- a/policy/centos7/k3s.te
+++ b/policy/centos7/k3s.te
@@ -6,6 +6,16 @@ gen_require(`
 filetrans_pattern(container_runtime_t, container_var_lib_t, container_runtime_exec_t, dir, "data")
 
 gen_require(`
+    type container_runtime_t, container_runtime_exec_t, container_lock_t;
+')
+filetrans_pattern(container_runtime_t, container_runtime_exec_t, container_lock_t, file, ".lock")
+
+gen_require(`
+    type container_runtime_t, container_runtime_exec_t, container_config_t;
+')
+filetrans_pattern(container_runtime_t, container_runtime_exec_t, container_config_t, dir, "etc")
+
+gen_require(`
     type container_runtime_t, container_var_lib_t, container_file_t;
 ')
 filetrans_pattern(container_runtime_t, container_var_lib_t, container_file_t, dir, "storage")

--- a/policy/centos8/k3s.fc
+++ b/policy/centos8/k3s.fc
@@ -13,8 +13,8 @@
 #/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.*      <<none>>
 #/var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?         gen_context(system_u:object_r:container_share_t,s0)
 #/var/lib/rancher/k3s/data(/.*)?                                     gen_context(system_u:object_r:container_runtime_exec_t,s0)
-/var/lib/rancher/k3s/data/.lock                                      gen_context(system_u:object_r:container_lock_t,s0)
-/var/lib/rancher/k3s/data/[^/]*/etc(/.*)?                            gen_context(system_u:object_r:container_config_t,s0)
+#/var/lib/rancher/k3s/data/.lock                                     gen_context(system_u:object_r:container_lock_t,s0)
+#/var/lib/rancher/k3s/data/[^/]*/etc(/.*)?                           gen_context(system_u:object_r:container_config_t,s0)
 #/var/lib/rancher/k3s/storage(/.*)?                                  gen_context(system_u:object_r:container_file_t,s0)
 #/var/log/containers(/.*)?                                           gen_context(system_u:object_r:container_log_t,s0)
 #/var/log/pods(/.*)?                                                 gen_context(system_u:object_r:container_log_t,s0)

--- a/policy/centos8/k3s.fc
+++ b/policy/centos8/k3s.fc
@@ -13,6 +13,8 @@
 #/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.*      <<none>>
 #/var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?         gen_context(system_u:object_r:container_share_t,s0)
 #/var/lib/rancher/k3s/data(/.*)?                                     gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/var/lib/rancher/k3s/data/.lock                                      gen_context(system_u:object_r:container_lock_t,s0)
+/var/lib/rancher/k3s/data/[^/]*/etc(/.*)?                            gen_context(system_u:object_r:container_config_t,s0)
 #/var/lib/rancher/k3s/storage(/.*)?                                  gen_context(system_u:object_r:container_file_t,s0)
 #/var/log/containers(/.*)?                                           gen_context(system_u:object_r:container_log_t,s0)
 #/var/log/pods(/.*)?                                                 gen_context(system_u:object_r:container_log_t,s0)

--- a/policy/centos8/k3s.te
+++ b/policy/centos8/k3s.te
@@ -6,6 +6,16 @@ gen_require(`
 filetrans_pattern(container_runtime_t, container_var_lib_t, container_runtime_exec_t, dir, "data")
 
 gen_require(`
+    type container_runtime_t, container_runtime_exec_t, container_lock_t;
+')
+filetrans_pattern(container_runtime_t, container_runtime_exec_t, container_lock_t, file, ".lock")
+
+gen_require(`
+    type container_runtime_t, container_runtime_exec_t, container_config_t;
+')
+filetrans_pattern(container_runtime_t, container_runtime_exec_t, container_config_t, dir, "etc")
+
+gen_require(`
     type container_runtime_t, container_var_lib_t, container_file_t;
 ')
 filetrans_pattern(container_runtime_t, container_var_lib_t, container_file_t, dir, "storage")

--- a/policy/microos/k3s.fc
+++ b/policy/microos/k3s.fc
@@ -13,8 +13,8 @@
 #/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.*      <<none>>
 #/var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?         gen_context(system_u:object_r:container_share_t,s0)
 #/var/lib/rancher/k3s/data(/.*)?                                     gen_context(system_u:object_r:container_runtime_exec_t,s0)
-/var/lib/rancher/k3s/data/.lock                                      gen_context(system_u:object_r:container_lock_t,s0)
-/var/lib/rancher/k3s/data/[^/]*/etc(/.*)?                            gen_context(system_u:object_r:container_config_t,s0)
+#/var/lib/rancher/k3s/data/.lock                                     gen_context(system_u:object_r:container_lock_t,s0)
+#/var/lib/rancher/k3s/data/[^/]*/etc(/.*)?                           gen_context(system_u:object_r:container_config_t,s0)
 #/var/lib/rancher/k3s/storage(/.*)?                                  gen_context(system_u:object_r:container_file_t,s0)
 #/var/log/containers(/.*)?                                           gen_context(system_u:object_r:container_log_t,s0)
 #/var/log/pods(/.*)?                                                 gen_context(system_u:object_r:container_log_t,s0)

--- a/policy/microos/k3s.fc
+++ b/policy/microos/k3s.fc
@@ -13,6 +13,8 @@
 #/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.*      <<none>>
 #/var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?         gen_context(system_u:object_r:container_share_t,s0)
 #/var/lib/rancher/k3s/data(/.*)?                                     gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/var/lib/rancher/k3s/data/.lock                                      gen_context(system_u:object_r:container_lock_t,s0)
+/var/lib/rancher/k3s/data/[^/]*/etc(/.*)?                            gen_context(system_u:object_r:container_config_t,s0)
 #/var/lib/rancher/k3s/storage(/.*)?                                  gen_context(system_u:object_r:container_file_t,s0)
 #/var/log/containers(/.*)?                                           gen_context(system_u:object_r:container_log_t,s0)
 #/var/log/pods(/.*)?                                                 gen_context(system_u:object_r:container_log_t,s0)

--- a/policy/microos/k3s.te
+++ b/policy/microos/k3s.te
@@ -6,6 +6,16 @@ gen_require(`
 filetrans_pattern(container_runtime_t, container_var_lib_t, container_runtime_exec_t, dir, "data")
 
 gen_require(`
+    type container_runtime_t, container_runtime_exec_t, container_lock_t;
+')
+filetrans_pattern(container_runtime_t, container_runtime_exec_t, container_lock_t, file, ".lock")
+
+gen_require(`
+    type container_runtime_t, container_runtime_exec_t, container_config_t;
+')
+filetrans_pattern(container_runtime_t, container_runtime_exec_t, container_config_t, dir, "etc")
+
+gen_require(`
     type container_runtime_t, container_var_lib_t, container_file_t;
 ')
 filetrans_pattern(container_runtime_t, container_var_lib_t, container_file_t, dir, "storage")

--- a/test/centos8/Vagrantfile
+++ b/test/centos8/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure("2") do |config|
   config.vagrant.plugins = ["vagrant-k3s"]
 
-  config.vm.box = "centos/8"
+  config.vm.box = "centos/stream8"
 
   %w[hyperv libvirt virtualbox vmware_desktop].each do |p|
     config.vm.provider p do |v, o|
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.synced_folder '../../dist/centos8/noarch', '/vagrant/dist', type: 'rsync'
 
-  config.vm.provision :shell, run: 'once', inline: 'set -x; dnf install -y https://github.com/k3s-io/k3s-selinux/releases/download/v0.4.stable.1/k3s-selinux-0.4-1.el8.noarch.rpm'
+#   config.vm.provision :shell, run: 'once', inline: 'set -x; dnf install -y https://github.com/k3s-io/k3s-selinux/releases/download/v0.4.stable.1/k3s-selinux-0.4-1.el8.noarch.rpm'
   config.vm.provision :shell, run: 'once' do |sh|
     sh.inline = <<~EOF
       #!/usr/bin/env bash
@@ -27,11 +27,12 @@ Vagrant.configure("2") do |config|
   end
 
   # vagrant [up|provision] --provision-with=k3s
-  config.vm.provision :k3s, run: 'never' do |k3s|
+  config.vm.provision :k3s, run: 'once' do |k3s|
+    k3s.config_mode = '0644'
     k3s.env = <<~ENV
       INSTALL_K3S_NAME=server
       INSTALL_K3S_SKIP_SELINUX_RPM=true
-      INSTALL_K3S_VERSION=v1.21.5+k3s2
+      INSTALL_K3S_CHANNEL=v1.21
       K3S_KUBECONFIG_MODE=0644
       K3S_SELINUX=true
       K3S_TOKEN=vagrant


### PR DESCRIPTION
- `${K3S_DATA_DIR}/.lock` => `container_lock_t`
- `${K3S_DATA_DIR}/*/etc/` => `container_config_t`

Addresses part of k3s-io/k3s#4401

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
