### PR TITLE
Fix centos 7 policy

### DIFF
--- a/policy/centos7/k3s.if
+++ b/policy/centos7/k3s.if
@@ -10,7 +10,7 @@
 #
 template(`k3s_runtime_domain_template',`
 	gen_require(`
-		attribute container_runtime_domain, exec_type;
+		attribute container_domain, exec_type;
 		role system_r, sysadm_r;
 	')
 
@@ -23,5 +23,5 @@ template(`k3s_runtime_domain_template',`
 	domain_type($1_t)
 	domain_entry_file($1_domain, $1_t)
 
-	admin_pattern(container_runtime_domain, $1_t)
+	admin_pattern(container_domain, $1_t)
 ')

--- a/policy/centos7/k3s.te
+++ b/policy/centos7/k3s.te
@@ -6,21 +6,21 @@ files_type(k3s_data_t);
 
 ##### type: k3s_lock_t
 type k3s_lock_t;
-files_lock_file(k3s_lock_t)
+files_lock_file(k3s_lock_t);
 
 ##### type: k3s_root_t, attr: k3s_root_domain
-k3s_runtime_domain_template(k3s_root)
+k3s_runtime_domain_template(k3s_root);
 
 gen_require(`
-    attribute container_runtime_domain;
+    attribute container_domain;
     type container_runtime_exec_t, container_runtime_t;
     type container_file_t, container_share_t;
     type container_var_lib_t, var_lib_t;
     type container_log_t, var_log_t;
 ')
-admin_pattern(container_runtime_domain, k3s_data_t)
-admin_pattern(container_runtime_domain, k3s_lock_t)
-files_lock_filetrans(container_runtime_domain, k3s_lock_t, { dir file })
+admin_pattern(container_domain, k3s_data_t)
+admin_pattern(container_domain, k3s_lock_t)
+files_lock_filetrans(container_domain, k3s_lock_t, { dir file })
 filetrans_pattern(container_runtime_t, container_var_lib_t, k3s_data_t, dir, "data")
 filetrans_pattern(container_runtime_t, k3s_data_t, k3s_lock_t, file, ".lock")
 filetrans_pattern(container_runtime_t, k3s_data_t, k3s_root_t, dir, "bin")


### PR DESCRIPTION
Fix:

CentOS 7 comes with container-selinux version `container-selinux-2.119.2-1.911c772.el7_8.noarch` which has different domain than the one we use in k3s-selinux v1.0:

```
# seinfo -acontainer_domain -x
   container_domain
      spc_t
      container_build_t
      container_logreader_t
      container_t
```
The fix will replace `container_runtime_domain` which is used recent container-selinux versions.

Note: The fix will risk two things:

- Different policy maintenance for el7 vs el8
- Changing contexts for existing setups on Centos7
cc @cwayne18 
