### PR TITLE
Bump pip/setuptools version; switch to https for git clone

### DIFF
--- a/policy/centos7/scripts/upload-repo
+++ b/policy/centos7/scripts/upload-repo
@@ -7,9 +7,9 @@ popd
 
 yum install -y epel-release
 yum install -y git python2-pip python-deltarpm
-pip install boto3==1.17.112
+pip install --cache-dir=/var/cache/pip --upgrade 'boto3==1.17.112' 'pip<21.0' 'setuptools<45.0'
 pip install --cache-dir=/var/cache/pip/ \
-  git+git://github.com/Voronenko/rpm-s3.git@5695c6ad9a08548141d3713328e1bd3f533d137e
+  git+https://github.com/Voronenko/rpm-s3.git@5695c6ad9a08548141d3713328e1bd3f533d137e
 
 if [ -z "$RPM_CHANNEL" ]; then
   echo "RPM_CHANNEL not defined, failing rpm upload"

--- a/policy/centos8/scripts/upload-repo
+++ b/policy/centos8/scripts/upload-repo
@@ -7,9 +7,9 @@ popd
 
 yum install -y epel-release
 yum install -y git python2-pip python-deltarpm
-pip install boto3==1.17.112
+pip install --cache-dir=/var/cache/pip --upgrade 'boto3==1.17.112' 'pip<21.0' 'setuptools<45.0'
 pip install --cache-dir=/var/cache/pip/ \
-  git+git://github.com/Voronenko/rpm-s3.git@5695c6ad9a08548141d3713328e1bd3f533d137e
+  git+https://github.com/Voronenko/rpm-s3.git@5695c6ad9a08548141d3713328e1bd3f533d137e
 
 if [ -z "$RPM_CHANNEL" ]; then
   echo "RPM_CHANNEL not defined, failing rpm upload"

--- a/policy/microos/scripts/upload-repo
+++ b/policy/microos/scripts/upload-repo
@@ -7,9 +7,9 @@ popd
 
 yum install -y epel-release
 yum install -y git python2-pip python-deltarpm
-pip install boto3==1.17.112
+pip install --cache-dir=/var/cache/pip --upgrade 'boto3==1.17.112' 'pip<21.0' 'setuptools<45.0'
 pip install --cache-dir=/var/cache/pip/ \
-  git+git://github.com/Voronenko/rpm-s3.git@5695c6ad9a08548141d3713328e1bd3f533d137e
+  git+https://github.com/Voronenko/rpm-s3.git@5695c6ad9a08548141d3713328e1bd3f533d137e
 
 if [ -z "$RPM_CHANNEL" ]; then
   echo "RPM_CHANNEL not defined, failing rpm upload"


### PR DESCRIPTION
Should fix CI failures: https://drone-publish.k3s.io/k3s-io/k3s-selinux/19/1/4

```
You are using pip version 8.1.2, however version 22.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ pip install --cache-dir=/var/cache/pip/ git+git://github.com/Voronenko/rpm-s3.git@5695c6ad9a08548141d3713328e1bd3f533d137e
Collecting git+git://github.com/Voronenko/rpm-s3.git@5695c6ad9a08548141d3713328e1bd3f533d137e
  Cloning git://github.com/Voronenko/rpm-s3.git (to 5695c6ad9a08548141d3713328e1bd3f533d137e) to /tmp/pip-0Uvhy1-build
fatal: unable to connect to github.com:
github.com[0: 140.82.113.4]: errno=Connection timed out
```