### PR TITLE
ci: configure Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    reviewers:
+      - "k3s-io/k3s-dev"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Configure Dependabot for daily updates to container images in Dockerfiles.

Related-to: k3s-io/k3s#7440